### PR TITLE
Linux test fixes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/APTrust/dart-runner v1.0.5 h1:19J7p8uxUeQvc+SZU5Yx9/NoC2TF3vW5IhpwM1AafbE=
+github.com/APTrust/dart-runner v1.0.5/go.mod h1:nTTycLK5i09QSBv+nlrbHLJKdilzucrD4414X1aLlPA=
 github.com/APTrust/preservation-services v0.0.0-20260303193921-0cefb01f4e00 h1:IlQVCaLQuY/NTdxZ8dYAy9XTe9sBuO4tNe3vtSKbRPM=
 github.com/APTrust/preservation-services v0.0.0-20260303193921-0cefb01f4e00/go.mod h1:o7ONFl3oidejePbVFs550zyxe+N4h+5sUMQWfuhkqNA=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -51,7 +51,10 @@ sftp_image_name() {
 start_minio() {
     echo "Starting Minio container"
     docker rm -f dart-minio > /dev/null 2>&1 || true
-    DOCKER_MINIO_ID=$(docker run --name dart-minio --rm -p 9899:9000 -p 9001:9001 -v ~/tmp/minio:/data -e MINIO_ROOT_USER="$MINIO_USER" -e MINIO_ROOT_PASSWORD="$MINIO_PASSWORD" -d quay.io/minio/minio server /data --console-address ":9001")
+    # Must exist and be owned by the current user before the container starts,
+    # otherwise Docker auto-creates it as root and --user can't write to /data.
+    mkdir -p "$HOME/tmp/minio"
+    DOCKER_MINIO_ID=$(docker run --name dart-minio --rm -p 9899:9000 -p 9001:9001 -v ~/tmp/minio:/data --user "$(id -u):$(id -g)" -e MINIO_ROOT_USER="$MINIO_USER" -e MINIO_ROOT_PASSWORD="$MINIO_PASSWORD" -d quay.io/minio/minio server /data --console-address ":9001")
     local exit_code=$?
     DOCKER_MINIO_ID=$(echo "$DOCKER_MINIO_ID" | tr -d '[:space:]')
     if [ $exit_code -eq 0 ]; then
@@ -124,22 +127,36 @@ start_sftp() {
     local image
     image=$(sftp_image_name)
     echo "Using SFTP config options from $sftp_dir"
-    docker rm -f dart-sftp > /dev/null 2>&1 || true
-    DOCKER_SFTP_ID=$(docker run --name dart-sftp --rm \
-        -v "$sftp_dir/sftp_user_key.pub:/home/key_user/.ssh/keys/sftp_user_key.pub:ro" \
+    DOCKER_SFTP_ID=$(docker run \
+        --ulimit nofile=512:512 \
+        -v "$sftp_dir/sftp_user_key.pub:/home/key_user/.ssh/keys/sftp_user_key.pub" \
+        -v "$sftp_dir/sftp_user_key.pub:/home/key_user/.ssh/keys/id_rsa.pub:ro" \
         -v "$sftp_dir/users.conf:/etc/sftp/users.conf:ro" \
         -p 2222:22 -d "$image")
     local exit_code=$?
-    DOCKER_SFTP_ID=$(echo "$DOCKER_SFTP_ID" | tr -d '\n')
+    DOCKER_SFTP_ID=$(echo "$DOCKER_SFTP_ID" | tr -d '[:space:]')
     if [ $exit_code -eq 0 ]; then
         echo "Started SFTP server with id $DOCKER_SFTP_ID"
-        echo "To log in and view the contents, use:"
+        echo "Waiting for SFTP server to be ready..."
+        local attempts=0
+        until timeout 1 bash -c '</dev/tcp/127.0.0.1/2222' > /dev/null 2>&1; do
+            attempts=$((attempts + 1))
+            if [ $attempts -ge 30 ]; then
+                echo "SFTP server did not become ready in time"
+                docker logs --tail 80 "$DOCKER_SFTP_ID" || true
+                return 1
+            fi
+            sleep 1
+        done
+        echo "To log in and view the contents, use"
         echo "sftp -P 2222 pw_user@localhost"
         echo "The password is 'password' without the quotes"
         SFTP_STARTED=true
+        return 0
     else
         echo "Error starting SFTP docker container. Is one already running?"
         echo "$DOCKER_SFTP_ID"
+        return 1
     fi
 }
 
@@ -183,6 +200,22 @@ cleanup() {
 }
 
 run_tests() {
+    if [ -n "${GOROOT:-}" ]; then
+        echo "Ignoring external GOROOT=$GOROOT to avoid toolchain mismatch"
+        unset GOROOT
+    fi
+    if [ -n "${GOTOOLDIR:-}" ]; then
+        echo "Ignoring external GOTOOLDIR=$GOTOOLDIR to avoid toolchain mismatch"
+        unset GOTOOLDIR
+    fi
+
+    local required_go
+    required_go=$(awk '/^go / {print $2; exit}' "$PROJECT_ROOT/go.mod")
+    if [ -n "$required_go" ]; then
+        export GOTOOLCHAIN="go${required_go}+auto"
+        echo "Using GOTOOLCHAIN=$GOTOOLCHAIN"
+    fi
+
     make_test_dirs
     start_minio
     start_sftp

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -54,7 +54,16 @@ start_minio() {
     # Must exist and be owned by the current user before the container starts,
     # otherwise Docker auto-creates it as root and --user can't write to /data.
     mkdir -p "$HOME/tmp/minio"
-    DOCKER_MINIO_ID=$(docker run --name dart-minio --rm -p 9899:9000 -p 9001:9001 -v ~/tmp/minio:/data --user "$(id -u):$(id -g)" -e MINIO_ROOT_USER="$MINIO_USER" -e MINIO_ROOT_PASSWORD="$MINIO_PASSWORD" -d quay.io/minio/minio server /data --console-address ":9001")
+
+    local user_args=()
+    # On Mac & Linux, run Minio server as current user so it doesn't
+    # write files as root. On Windows (MINGW), we need to run it without
+    # the user flags.
+    if [[ "$(uname -s)" != *MINGW* ]]; then
+        user_args=(--user "$(id -u):$(id -g)")
+    fi
+    DOCKER_MINIO_ID=$(docker run -p 9899:9000 -p 9001:9001 -v ~/tmp/minio:/data "${user_args[@]}" -e MINIO_ROOT_USER="$MINIO_USER" -e MINIO_ROOT_PASSWORD="$MINIO_PASSWORD" -d quay.io/minio/minio server /data --console-address ":9001")
+
     local exit_code=$?
     DOCKER_MINIO_ID=$(echo "$DOCKER_MINIO_ID" | tr -d '[:space:]')
     if [ $exit_code -eq 0 ]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -139,15 +139,17 @@ start_sftp() {
         echo "Started SFTP server with id $DOCKER_SFTP_ID"
         echo "Waiting for SFTP server to be ready..."
         local attempts=0
-        until timeout 1 bash -c '</dev/tcp/127.0.0.1/2222' > /dev/null 2>&1; do
-            attempts=$((attempts + 1))
-            if [ $attempts -ge 30 ]; then
-                echo "SFTP server did not become ready in time"
-                docker logs --tail 80 "$DOCKER_SFTP_ID" || true
-                return 1
-            fi
-            sleep 1
-        done
+        if [ "$(uname)" = "Linux" ]; then
+            until timeout 1 bash -c '</dev/tcp/127.0.0.1/2222' > /dev/null 2>&1; do
+                attempts=$((attempts + 1))
+                if [ $attempts -ge 30 ]; then
+                    echo "SFTP server did not become ready in time"
+                    docker logs --tail 80 "$DOCKER_SFTP_ID" || true
+                    return 1
+                fi
+                sleep 1
+            done
+        fi
         echo "To log in and view the contents, use"
         echo "sftp -P 2222 pw_user@localhost"
         echo "The password is 'password' without the quotes"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -133,6 +133,10 @@ stop_minio() {
 
 start_sftp() {
     local sftp_dir="$PROJECT_ROOT/testdata/sftp"
+    # Docker Desktop on Windows requires Windows-style paths for volume mounts
+    if [[ "$(uname -s)" == *MINGW* ]] || [[ "$(uname -s)" == *CYGWIN* ]]; then
+        sftp_dir=$(cygpath -w "$sftp_dir" | tr '\\' '/')
+    fi
     local image
     image=$(sftp_image_name)
     echo "Using SFTP config options from $sftp_dir"

--- a/server/controllers/controllers_test.go
+++ b/server/controllers/controllers_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/APTrust/dart-runner/constants"
 	"github.com/APTrust/dart-runner/core"
@@ -36,6 +37,7 @@ type StreamRecorder struct {
 	EventCount   int
 	ResultEvent  *core.EventMessage
 	LastEvent    *core.EventMessage
+	closeOnce    sync.Once
 	mutex        sync.RWMutex
 }
 
@@ -67,7 +69,9 @@ func (r *StreamRecorder) WriteString(data []byte) (int, error) {
 }
 
 func (r *StreamRecorder) close() {
-	r.closeChannel <- true
+	r.closeOnce.Do(func() {
+		close(r.closeChannel)
+	})
 }
 
 func NewStreamRecorder() *StreamRecorder {
@@ -77,8 +81,16 @@ func NewStreamRecorder() *StreamRecorder {
 		0,
 		nil,
 		nil,
+		sync.Once{},
 		sync.RWMutex{},
 	}
+}
+
+func waitForRecorderFlush(t *testing.T, recorder *StreamRecorder) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return recorder.Flushed
+	}, 30*time.Second, 250*time.Millisecond, "timeout waiting for SSE disconnect event")
 }
 
 type PostTestSettings struct {

--- a/server/controllers/job_run_controller_test.go
+++ b/server/controllers/job_run_controller_test.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/APTrust/dart-runner/constants"
 	"github.com/APTrust/dart-runner/core"
@@ -116,9 +115,7 @@ func TestJobRunExecute(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/jobs/run/%s", job.ID), nil)
 	dartServer.ServeHTTP(recorder, req)
 
-	for !recorder.Flushed {
-		time.Sleep(250 * time.Millisecond)
-	}
+	waitForRecorderFlush(t, recorder)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	html := recorder.Body.String()

--- a/server/controllers/upload_job_controller_test.go
+++ b/server/controllers/upload_job_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/APTrust/dart-runner/constants"
 	"github.com/APTrust/dart-runner/core"
@@ -155,11 +154,7 @@ func testUploadJobRun(t *testing.T, id string) {
 	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/upload_jobs/run/%s", id), nil)
 	dartServer.ServeHTTP(recorder, req)
 
-	// This should wrap up in <250 ms, but we'll give it
-	// as long as it needs.
-	for !recorder.Flushed {
-		time.Sleep(250 * time.Millisecond)
-	}
+	waitForRecorderFlush(t, recorder)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	html := recorder.Body.String()

--- a/server/controllers/validation_job_controller_test.go
+++ b/server/controllers/validation_job_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/APTrust/dart-runner/constants"
 	"github.com/APTrust/dart-runner/core"
@@ -133,11 +132,7 @@ func testValidationJobRun(t *testing.T, id string) {
 	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/validation_jobs/run/%s", id), nil)
 	dartServer.ServeHTTP(recorder, req)
 
-	// This should wrap up in <250 ms, but we'll give it
-	// as long as it needs.
-	for !recorder.Flushed {
-		time.Sleep(250 * time.Millisecond)
-	}
+	waitForRecorderFlush(t, recorder)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	html := recorder.Body.String()

--- a/server/controllers/workflow_controller_test.go
+++ b/server/controllers/workflow_controller_test.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/APTrust/dart-runner/constants"
 	"github.com/APTrust/dart-runner/core"
@@ -367,9 +366,7 @@ func testWorkflowRunBatch(t *testing.T, batchUrl string) {
 	req, _ := http.NewRequest(http.MethodGet, batchUrl, nil)
 	dartServer.ServeHTTP(recorder, req)
 
-	for !recorder.Flushed {
-		time.Sleep(250 * time.Millisecond)
-	}
+	waitForRecorderFlush(t, recorder)
 
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	html := recorder.Body.String()


### PR DESCRIPTION
This fixes a number of issues, including:

- Changes to atmoz/sftp container caused connections to fail unless container is started with --ulimit nofile=512:512
- Changes to atmoz/sftp container caused problem loading user config file, which caused container to die
- Fixed minio container so it doesn't write root-owned files to user's directory on Linux
- Fixed testing problems caused by mismatch between Go version in go.mod and Go toolchain version inherited from environment.
- DART now uses latest version of Dart Runner, bumped from 1.0.4 to 1.0.5.

All of these problems are fixed. Tested and working on Linux, MacOS and Windows.

Please run `.scripts/run.sh tests` on at least one OS for a sanity check.